### PR TITLE
Get PurgeCSS working with the starter project

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,6 +17,20 @@ module.exports = {
       },
     },
     'gatsby-plugin-offline',
-    'gatsby-plugin-purgecss'
+    {
+      resolve: 'gatsby-plugin-purgecss',
+      options: {
+        extractors: [
+          {
+            extractor: class {
+              static extract(content) {
+                return content.match(/[A-Za-z0-9-_:\/]+/g)
+              }
+            },
+            extensions: ['html', 'js']
+          }
+        ]
+      }
+    },
   ],
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build:css": "postcss src/styles/index.css -o src/index.css",
     "watch:css": "postcss src/styles/index.css -o src/index.css -w",
-    "build": "yarn run build:css && purgecss -c ./purgecss.config.js -o ./src/assets/styles && gatsby build",
+    "build": "yarn run build:css && gatsby build",
     "develop": "yarn run build:css && gatsby develop",
     "format": "prettier --write '**/*.js'",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Earlier today I realized that purgecss wasn't working properly (removing Tailwind classes like `md:flex` and `w-1/3`). After a lot of digging, I realized that gatsby-plugin-purgecss needs to be defined differently for it to work. I've opened an issue in their repo asking if you can define an external configuration file, but for the time being setting the options in gatsby-config.js directly works too.